### PR TITLE
[wip] Add webhook to disallow machine deletion

### DIFF
--- a/api/infrastructure/v1beta1/externalmachine_types.go
+++ b/api/infrastructure/v1beta1/externalmachine_types.go
@@ -39,6 +39,7 @@ type ExternalMachineStatus struct {
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 
 	// Addresses contains the IP and/or DNS addresses of the CoxEdge instances.
+	// +optional
 	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
 }
 
@@ -54,7 +55,8 @@ func (in *ExternalMachine) SetConditions(conditions clusterv1.Conditions) {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Machine to which this ExternalMachine belongs"
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Machine to which this ExternalMachine belongs"
+// +kubebuilder:printcolumn:name="Provider ID",type="string",JSONPath=".spec.providerID",description="The machine-specific provider identifier"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine infrastructure is ready for External instances"
 
 // ExternalMachine is the Schema for the externalclusters API

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,0 +1,25 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: cape-webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,16 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution 
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/commonName
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_externalcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_externalcontrolplanes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: externalcontrolplanes.controlplane.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_externalclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_externalclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: externalclusters.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_externalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_externalmachines.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: externalmachines.infrastructure.cluster.x-k8s.io
 spec:
@@ -19,7 +19,11 @@ spec:
   - additionalPrinterColumns:
     - description: Machine to which this ExternalMachine belongs
       jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
-      name: Machine
+      name: Cluster
+      type: string
+    - description: The machine-specific provider identifier
+      jsonPath: .spec.providerID
+      name: Provider ID
       type: string
     - description: Machine infrastructure is ready for External instances
       jsonPath: .status.ready

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,9 +21,9 @@ bases:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
@@ -41,39 +41,39 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-#vars:
+vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/default/manager_pull_policy.yaml
+++ b/config/default/manager_pull_policy.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: manager
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,11 +1,11 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: mutating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+#apiVersion: admissionregistration.k8s.io/v1
+#kind: MutatingWebhookConfiguration
+#metadata:
+#  name: mutating-webhook-configuration
+#  annotations:
+#    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,6 +30,7 @@ spec:
       - args:
         - run
         - --leader-elect
+        - -v=5
         image: controller:latest
         name: manager
         securityContext:

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,25 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,27 @@
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-machine-cluster-x-k8s-io-v1beta1-external
+  failurePolicy: Fail
+  name: machine-external.kb.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - DELETE
+    resources:
+    - machines
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/controllers/externalcontrolplane_controller.go
+++ b/controllers/externalcontrolplane_controller.go
@@ -65,7 +65,7 @@ func (r *ExternalControlPlaneReconciler) SetupWithManager(ctx context.Context, m
 func (r *ExternalControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	log.Info("Fetching ExternalControlPLane from storage")
+	log.Info("Fetching ExternalControlPlane from storage")
 	var externalControlPlane externalv1.ExternalControlPlane
 	if err := r.Get(ctx, req.NamespacedName, &externalControlPlane); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/cape/import.go
+++ b/pkg/cape/import.go
@@ -12,41 +12,44 @@ import (
 	"github.com/platform9/pf9-sdk-go/pf9/qbert"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ClusterImporter struct {
-	MgmtClient client.Client
-	Log        *zap.SugaredLogger
+	MgmtClient       client.Client
+	MgmtClientLegacy kubernetes.Interface
+	Log              *zap.SugaredLogger
 }
 
-func (c *ClusterImporter) ImportClusterResources(ctx context.Context, ClusterName string, MgmtClusterNamespace string, host string, port int, workloadClusterKubeconfig string) error {
+func (c *ClusterImporter) ImportClusterResources(ctx context.Context, clusterName string, mgmtClusterNamespace string, host string, port int, workloadClusterKubeconfig string) error {
 	resources := []client.Object{
 		&clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      ClusterName,
-				Namespace: MgmtClusterNamespace,
+				Name:      clusterName,
+				Namespace: mgmtClusterNamespace,
 			},
 			Spec: clusterv1.ClusterSpec{
 				ControlPlaneRef: &corev1.ObjectReference{
 					APIVersion: externalcontrolplanev1.GroupVersion.String(),
 					Kind:       "ExternalControlPlane",
-					Name:       ClusterName,
+					Name:       clusterName,
 				},
 				InfrastructureRef: &corev1.ObjectReference{
 					APIVersion: externalinfrav1.GroupVersion.String(),
 					Kind:       "ExternalCluster",
-					Name:       ClusterName,
+					Name:       clusterName,
 				},
 			},
 		},
 		&externalinfrav1.ExternalCluster{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      ClusterName,
-				Namespace: MgmtClusterNamespace,
+				Name:      clusterName,
+				Namespace: mgmtClusterNamespace,
 			},
 			Spec: externalinfrav1.ExternalClusterSpec{
 				ControlPlaneEndpoint: clusterv1.APIEndpoint{
@@ -57,30 +60,55 @@ func (c *ClusterImporter) ImportClusterResources(ctx context.Context, ClusterNam
 		},
 		&externalcontrolplanev1.ExternalControlPlane{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      ClusterName,
-				Namespace: MgmtClusterNamespace,
+				Name:      clusterName,
+				Namespace: mgmtClusterNamespace,
 			},
 			Spec: externalcontrolplanev1.ExternalControlPlaneSpec{},
 		},
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-kubeconfig", ClusterName),
-				Namespace: MgmtClusterNamespace,
-			},
-			Immutable: pointer.Bool(true),
-			StringData: map[string]string{
-				"value": workloadClusterKubeconfig,
-			},
-			Type: clusterv1.ClusterSecretType,
-		},
+		// &corev1.Secret{
+		// 	ObjectMeta: metav1.ObjectMeta{
+		// 		Name:      fmt.Sprintf("%s-kubeconfig", clusterName),
+		// 		Namespace: mgmtClusterNamespace,
+		// 	},
+		// 	Immutable: pointer.Bool(true),
+		// 	StringData: map[string]string{
+		// 		"value": workloadClusterKubeconfig,
+		// 	},
+		// 	Type: clusterv1.ClusterSecretType,
+		// },
 	}
 	for _, resource := range resources {
 		c.Log.Debugf("Creating resource %T: %s/%s", resource, resource.GetNamespace(), resource.GetName())
 		err := c.MgmtClient.Create(ctx, resource)
 		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				c.Log.Warnf("Resource already exists: %v", err)
+			} else {
+				return err
+			}
+		}
+	}
+
+	// Hack: use the legacy client because the client.Client is not creating secrets (with Sunpike)
+	_, err := c.MgmtClientLegacy.CoreV1().Secrets(mgmtClusterNamespace).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-kubeconfig", clusterName),
+			Namespace: mgmtClusterNamespace,
+		},
+		Immutable: pointer.Bool(true),
+		StringData: map[string]string{
+			"value": workloadClusterKubeconfig,
+		},
+		Type: clusterv1.ClusterSecretType,
+	}, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			c.Log.Warnf("Resource already exists: %v", err)
+		} else {
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -20,8 +20,8 @@ func NewCmdRoot() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:              "pf9",
-		Short:            "CLI for interacting with PMK and other PF9 services",
+		Use:              "cape",
+		Short:            "CLI for running and interacting with external clusters in CAPI",
 		PersistentPreRun: cobras.Run(opts),
 	}
 

--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -1,0 +1,59 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type MachineWebhook struct {
+	Client  client.Client
+	decoder *admission.Decoder
+}
+
+var _ admission.Handler = (*MachineWebhook)(nil)
+
+func (n *MachineWebhook) InjectDecoder(d *admission.Decoder) error {
+	n.decoder = d
+	return nil
+}
+
+func (n *MachineWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	machine := &clusterv1.Machine{}
+	err := n.decoder.Decode(req, machine)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Only handle machines that are external machines
+	if machine.Spec.InfrastructureRef.Kind != "ExternalMachine" {
+		return admission.Allowed("")
+	}
+
+	// Only handle delete requests
+	if req.Operation != admissionv1.Delete {
+		return admission.Allowed("")
+	}
+
+	// Check if the cluster is being deleted
+	cluster, err := util.GetClusterFromMetadata(ctx, n.Client, machine.ObjectMeta)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	// Only allow deletion when the cluster is being deleted. This is needed
+	// because in the CAPI core logic, machines being deleted separately from
+	// the cluster will also cause the node to be drained and deleted.
+	// TODO upstream a patch to skip node preemption/deletion when deleting a machine.
+	if cluster.DeletionTimestamp == nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("external machines are read-only"))
+	}
+
+	return admission.Allowed("")
+}


### PR DESCRIPTION
The webhooks are meant to limit the user interactions with CAPE resources. For now, they should  not be able to delete machines (because they are read-only).

Current status: not completely working yet